### PR TITLE
ci: run checks on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: build
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0.0'
+          bundler-cache: true
+      - name: Rubocop
+        run: bundle exec rubocop
+      - name: RSpec
+        run: bundle exec rspec


### PR DESCRIPTION
## Summary
- run rubocop and rspec on push via CI

## Testing
- not run (Ruby 4.0.0 required locally)